### PR TITLE
Forum Notifier Event Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Internal
 ### Issues
 
+## 2.18.3
+### Internal
+- Enhance `Bot::on_error` logging to include traceback information where available
+- Update `Admin` cog private event notifications to use `on_message` to avoid `Forbidden (error code: 40058)` issues with `on_thread_create`
+
 ## 2.18.2
 ### Internal
 - Add private event notifications to `Admin` cog

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -868,26 +868,29 @@ class Admin(commands.Cog):
                         await try_to_send_buffer(channel, buffer, True)
 
     @commands.Cog.listener()
-    async def on_thread_create(self, thread: discord.Thread) -> None:
+    async def on_message(self, message: discord.Message) -> None:
         """
         Adds all members of the forum to newly created threads.
 
         Parameters:
-            thread (discord.Thread): The created thread.
+            message (discord.Message): The newly created message.
 
         Returns:
             None.
         """
 
-        if thread.guild.id != 1084581614878728305:
+        if not message.guild or message.guild.id != 1084581614878728305:
+            return
+
+        if not isinstance(message.channel, discord.Thread) or message.id != message.channel.id:
             return
 
         members_to_add = [
-            member for member in thread.guild.members if
-            not member.bot and member.id not in [146517998205796352, thread.owner_id]
+            member for member in message.guild.members if
+            not member.bot and member.id not in [146517998205796352, message.author.id]
         ]
 
-        await thread.send(
+        await message.channel.send(
             f'_Tagging Members for Notifications: {", ".join([member.mention for member in members_to_add])}_'
         )
 

--- a/dreambot.py
+++ b/dreambot.py
@@ -180,12 +180,17 @@ class DreamBot(Bot):
             None.
         """
 
-        await super().on_error(event_method, *args, **kwargs)
-
         _, exception, _ = exc_info()
 
         if exception and isinstance(exception, Exception):
+            bot_logger.error(
+                f"Encountered exception in '{event_method}'",
+                exc_info=(type(exception), exception, exception.__traceback__),
+            )
+
             await self.report_exception(exception)
+        else:
+            await super().on_error(event_method, *args, **kwargs)
 
     def report_command_failure(self, ctx: Context) -> None:
         """

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -40,7 +40,7 @@ from fuzzywuzzy import fuzz  # type: ignore
 
 from utils.logging_formatter import bot_logger
 
-VERSION = '2.18.2'
+VERSION = '2.18.3'
 
 ChoiceT = TypeVar('ChoiceT', str, int, float, Union[str, int, float])
 


### PR DESCRIPTION
- Replaces `on_thread_create` with `on_message` to avoid known state issue
  - `Forbidden: 403 Forbidden (error code: 40058): Cannot message this thread until after the post author has sent an initial message.`
  - Thread creation can be checked in `on_message` using the guarantee that `Message.id == Channel.id` during creation

### 🛠 Pull Request Checklist
- [x] Was the changelog updated?
- [x] Was the version incremented? (if necessary)